### PR TITLE
forward: fastest; qtype: any

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,22 @@ plugins:
         - addr: "8.8.8.8"
 ```
 
+## fastest and fastest_timeout
+
+`forward` 插件有两个新的选项 `fastest` 和 `fastest_timeout`。 `fastest_timeout` 的时间单位是毫秒。`fastest`为 `true` 时，得到上游的回应后会 ping 所有 IP 地址并只返回延迟最低的地址。该功能由上游的 AdguardTeam 的 fastip 提供。仅建议对本机或局域网的设备启用这个选项，为公网提供服务时启用这个选项会导致错误判断（客户端的网络 ping 结果与服务器的不同）。
+
+The `forward` plugin has two new options: `fastest` and `fastest_timeout`. The time unit for `fastest_timeout` is milliseconds. When `fastest` is set to `true`, it will ping all IP addresses after receiving responses from all upstream servers and will only return the address with the lowest latency. This feature is provided by AdguardTeam’s `fastip`. It is recommended to enable this option only for local or LAN devices, as enabling it for public-facing services may result in incorrect assessments (the client’s network ping results differ from the server’s).
+
+```yaml
+plugins:
+  - tag: "forward"
+    type: "forward"
+    args:
+      fastest: true
+      upstream:
+        - addr: "8.8.8.8"
+```
+
 # 配置文件结构/Configuration File Structure
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ plugins:
 
 ## fastest and fastest_timeout
 
-`forward` 插件有两个新的选项 `fastest` 和 `fastest_timeout`。 `fastest_timeout` 的时间单位是毫秒。`fastest`为 `true` 时，得到上游的回应后会 ping 所有 IP 地址并只返回延迟最低的地址。该功能由上游的 AdguardTeam 的 fastip 提供。仅建议对本机或局域网的设备启用这个选项，为公网提供服务时启用这个选项会导致错误判断（客户端的网络 ping 结果与服务器的不同）。
+`forward` 插件有两个新的选项 `fastest` 和 `fastest_timeout`。 `fastest_timeout` 的时间单位是毫秒。`fastest`为 `true` 时，得到上游的回应后会 ping 所有 IP 地址并只返回延迟最低的地址。该功能由上游的 AdguardTeam 的 fastip 提供。仅对请求来源是私有地址（例如10.0.0.0/8）的有效。
 
-The `forward` plugin has two new options: `fastest` and `fastest_timeout`. The time unit for `fastest_timeout` is milliseconds. When `fastest` is set to `true`, it will ping all IP addresses after receiving responses from all upstream servers and will only return the address with the lowest latency. This feature is provided by AdguardTeam’s `fastip`. It is recommended to enable this option only for local or LAN devices, as enabling it for public-facing services may result in incorrect assessments (the client’s network ping results differ from the server’s).
+The `forward` plugin has two new options: `fastest` and `fastest_timeout`. The time unit for `fastest_timeout` is milliseconds. When `fastest` is set to `true`, it will ping all IP addresses after receiving responses from all upstream servers and will only return the address with the lowest latency. This feature is provided by AdguardTeam’s `fastip`. Only effective on queries from private addresses like 10.0.0.0/8.
 
 ```yaml
 plugins:

--- a/plugin/executable/blackhole/blackhole.go
+++ b/plugin/executable/blackhole/blackhole.go
@@ -99,6 +99,7 @@ func newBlackHole(bp *coremain.BP, args *Args) (*blackHole, error) {
 // sets qCtx.R() with empty response with rcode = Args.RCode.
 // drops qCtx.R() if Args.RCode < 0
 // It never returns an error.
+// It will replace the existing response if placed after forwarding plugin. No need to drop response.
 func (b *blackHole) Exec(ctx context.Context, qCtx *query_context.Context, next executable_seq.ExecutableChainNode) error {
 	b.exec(qCtx)
 	return executable_seq.ExecChainNode(ctx, qCtx, next)

--- a/plugin/executable/forward/forward.go
+++ b/plugin/executable/forward/forward.go
@@ -213,7 +213,7 @@ func (f *forwardPlugin) exec(ctx context.Context, qCtx *query_context.Context, s
 	go func() {
 		var r *dns.Msg
 		var err error
-		if f.fastest != nil {
+		if f.fastest != nil && !qCtx.ReqMeta().ClientAddr.IsPrivate() {
 			r, _, err = f.fastest.ExchangeFastest(q, f.upstreams) 
 		} else {
 			r, _, err = upstream.ExchangeParallel(f.upstreams, q)

--- a/plugin/executable/forward/forward.go
+++ b/plugin/executable/forward/forward.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/AdguardTeam/dnsproxy/fastip"
 	"github.com/AdguardTeam/dnsproxy/upstream"
 	"github.com/miekg/dns"
 	"github.com/sieveLau/mosdns/v4-maintenance/coremain"
@@ -51,6 +52,7 @@ type forwardPlugin struct {
 
 	upstreams []upstream.Upstream
 	autoRetry bool
+	fastest   *fastip.FastestAddr
 }
 
 type Args struct {
@@ -61,6 +63,8 @@ type Args struct {
 	Bootstrap          []string         `yaml:"bootstrap"`
 	TrustCA            string           `yaml:"trust_ca"`
 	AutoRetry	       bool             `yaml:"auto_retry"`
+	Fastest            bool             `yaml:"fastest"`
+	FastestTimetout	   int              `yaml:"fastest_timeout"`
 }
 
 type UpstreamConfig struct {
@@ -83,10 +87,20 @@ func newForwarder(bp *coremain.BP, args *Args) (*forwardPlugin, error) {
 
 	f := new(forwardPlugin)
 	f.BP = bp
-	if args.AutoRetry {
-		f.autoRetry = true
+	f.autoRetry = args.AutoRetry
+	
+	if args.Fastest {
+		var duration int
+		if args.FastestTimetout > 0 {
+			duration = args.FastestTimetout
+		} else {
+			duration = 0
+		}
+		fastConfig := new(fastip.Config)
+		fastConfig.PingWaitTimeout = time.Millisecond * time.Duration(duration)
+		f.fastest = fastip.New(fastConfig)
 	} else {
-		f.autoRetry = false
+		f.fastest = nil
 	}
 
 	for i, conf := range args.UpstreamConfig {
@@ -197,7 +211,13 @@ func (f *forwardPlugin) exec(ctx context.Context, qCtx *query_context.Context, s
 	}
 	c := make(chan res, 1)
 	go func() {
-		r, _, err := upstream.ExchangeParallel(f.upstreams, q)
+		var r *dns.Msg
+		var err error
+		if f.fastest != nil {
+			r, _, err = f.fastest.ExchangeFastest(q, f.upstreams) 
+		} else {
+			r, _, err = upstream.ExchangeParallel(f.upstreams, q)
+		}
 		c <- res{
 			r:   r,
 			err: err,

--- a/plugin/matcher/query_matcher/query_matcher.go
+++ b/plugin/matcher/query_matcher/query_matcher.go
@@ -58,6 +58,13 @@ func init() {
 			return &queryIsEDNS0{BP: bp}, nil
 		},
 	)
+
+	coremain.RegNewPersetPluginFunc(
+		"_qtype_any",
+		func(bp *coremain.BP) (coremain.Plugin, error) {
+			return newQueryMatcher(bp, &Args{QType: []int{int(dns.TypeANY)}})
+		},
+	)
 }
 
 var _ coremain.MatcherPlugin = (*queryMatcher)(nil)


### PR DESCRIPTION
Add fastest to forward plugin, only effective on queries from private addresses.
Add new predefined query matcher "_qtype_any".